### PR TITLE
Adding note to readme about annotation compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Library version | Play Version  | Swagger Spec version |  Scala Version |
     1.2         |   2.4         |          1.2         | 2.10  
     1.3         |   2.4         |          1.2         | 2.10, 2.11
     1.4         |   2.4         |          1.2         | 2.10, 2.11
+    
+**Note:** swagger-core 1.5 is not yet supported, so annotations from `io.swagger.annotations._`
+will be ignored! Use `com.wordnik.swagger.annotations._`instead.
 
 # Installation
 add to your build.sbt


### PR DESCRIPTION
I spent the last few hours banging my head against a wall, because swagger would just ignore my annotations.

As it turns out, your PlayApiScanner compares the annotations to `com.wordnik.annotation.Api`and I was using `io.swagger.annotation.Api`, so the annotation was never found. I cannot fix the issue itself, but I added a note, so others don't run into the same problem.
